### PR TITLE
screenshot utilities, pixel-wise scroll with optional wrap

### DIFF
--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -7,11 +7,11 @@ This is a library for our Monochrome Nokia 5110 LCD Displays
 These displays use SPI to communicate, 4 or 5 pins are required to  
 interface
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
-Written by Limor Fried/Ladyada  for Adafruit Industries.  
+Written by Limor Fried/Ladyada for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above, and the splash screen below must be included in any redistribution
 *********************************************************************/
@@ -62,7 +62,7 @@ uint8_t pcd8544_buffer[LCDWIDTH * LCDHEIGHT / 8] = {
 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x0F, 0x1F, 0x3F, 0x7F, 0x7F,
 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0x7F, 0x1F, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
 
@@ -111,10 +111,10 @@ void Adafruit_PCD8544::drawPixel(int16_t x, int16_t y, uint16_t color) {
     return;
 
   // x is which column
-  if (color) 
-    pcd8544_buffer[x+ (y/8)*LCDWIDTH] |= _BV(y%8);  
+  if (color)
+    pcd8544_buffer[x+ (y/8)*LCDWIDTH] |= _BV(y%8);
   else
-    pcd8544_buffer[x+ (y/8)*LCDWIDTH] &= ~_BV(y%8); 
+    pcd8544_buffer[x+ (y/8)*LCDWIDTH] &= ~_BV(y%8);
 
   updateBoundingBox(x,y,x,y);
 }
@@ -124,7 +124,7 @@ uint8_t Adafruit_PCD8544::getPixel(int8_t x, int8_t y) {
   if ((x < 0) || (x >= LCDWIDTH) || (y < 0) || (y >= LCDHEIGHT))
     return 0;
 
-  return (pcd8544_buffer[x + (y/8) * LCDWIDTH] >> (y%8)) & 0x1;  
+  return (pcd8544_buffer[x + (y/8) * LCDWIDTH] >> (y%8)) & 0x1;
 }
 
 // capture a raw bitmap buffer into memory(SRAM)
@@ -137,7 +137,7 @@ void Adafruit_PCD8544::capture(uint8_t *bitmap) {
 void Adafruit_PCD8544::replace_P(uint8_t *bitmap) {
   memcpy_P(pcd8544_buffer,
            (uint8_t*) pgm_read_byte(bitmap - 256),
-           LCDWIDTH * LCDHEIGHT/8); 
+           LCDWIDTH * LCDHEIGHT/8);
   updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
 }
 
@@ -147,19 +147,19 @@ void Adafruit_PCD8544::replace_S(uint8_t *bitmap) {
   updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
 }
 
-// scroll screen 1 pixel to the left. 
+// scroll screen 1 pixel to the left.
 void Adafruit_PCD8544::scrollLeft(boolean WRAP) {
   uint8_t row, /*col, */ tmp;
   /*uint16_t ix;*/
   for (row=0; row < LCDHEIGHT/8; row++) {
-    tmp = pcd8544_buffer[row * LCDWIDTH];        // remember 1st byte
+    tmp = pcd8544_buffer[row * LCDWIDTH]; // remember 1st byte
     memcpy(pcd8544_buffer + (row * LCDWIDTH),
            pcd8544_buffer + (row * LCDWIDTH) + 1, // 1 line fast but ugly
-           LCDWIDTH - 1);
-//     for (col=0;col<LCDWIDTH-1;col++) { 
-//       ix=row*LCDWIDTH+col;                    // 3 lines readable but slower
-//       pcd8544_buffer[ix] = pcd8544_buffer[ix + 1]; 
-//     }
+           LCDWIDTH-1);
+// for (col=0;col<LCDWIDTH-1;col++) {
+// ix=row*LCDWIDTH+col; // 3 lines readable but slower
+// pcd8544_buffer[ix] = pcd8544_buffer[ix + 1];
+// }
     // place wrapped byte if required
     pcd8544_buffer[row * LCDWIDTH + LCDWIDTH-1] = WRAP ? tmp : 0x00;
   }
@@ -171,7 +171,7 @@ void Adafruit_PCD8544::scrollRight(boolean WRAP) {
   uint8_t row, col, tmp;
   uint16_t ix;
   for (row=0; row < LCDHEIGHT/8 ; row++) {
-    tmp = pcd8544_buffer[row * LCDWIDTH + LCDWIDTH-1];  // remember 1st byte
+    tmp = pcd8544_buffer[row * LCDWIDTH + LCDWIDTH-1]; // remember 1st byte
     for (col = (LCDWIDTH-1); col > 0; col--) {
       ix=row * LCDWIDTH + col;
       pcd8544_buffer[ix] = pcd8544_buffer[ix-1];
@@ -183,16 +183,16 @@ void Adafruit_PCD8544::scrollRight(boolean WRAP) {
 
 // scroll screen 1 pixel up
 void Adafruit_PCD8544::scrollUp(boolean WRAP) {
-  uint8_t row, col, carrybit, carryflag=0, carry[11];
+  uint8_t row, col, carrybit, carryflag=0, carry[((LCDWIDTH-1) / 8) + 1];
   uint16_t ix;
   
-  memset(&carry[0],0,11); // clear carry bits
+  memset(&carry[0],0,((LCDWIDTH-1) / 8) + 1); // clear carry bits
   // move from the bottom row backwards to 0
   for (row= LCDHEIGHT/8 ; row > 0; row--) {
     for (col=0; col < LCDWIDTH; col++) {
       ix=(uint16_t)(((row-1) * LCDWIDTH) + col);
       carrybit = 0x01 << col%8;
-      if (row < LCDHEIGHT/8 ) {        // 2nd-highest row and below
+      if (row < LCDHEIGHT/8 ) { // 2nd-highest row and below
         // retrieve and place carry bit from last(higher) row
         if (carry[col/8] & carrybit) { // carry is set
             carryflag = 1;
@@ -200,65 +200,65 @@ void Adafruit_PCD8544::scrollUp(boolean WRAP) {
         } else {
             carryflag = 0;
         }
-      } 
+      }
       // remember soon-to-be shifted bit
       if (pcd8544_buffer[ix] & 0x01) { // carry LSb is set
-        carry[col/8] |= carrybit;      //  remember LSb(top bit)
+        carry[col/8] |= carrybit;      // remember LSb(top bit)
       }
       pcd8544_buffer[ix] >>= 1;        // shift right(MSb->LSb(up)) 1 bit
-      if(carryflag) {           
+      if(carryflag) {
         pcd8544_buffer[ix] |= 0x80;    // place carry in MSb
       }
     } // for col
-  } // for row 
+  } // for row
   // wrap around shifted-up bits
   if (WRAP) {
     for (col=0; col < LCDWIDTH; col++) {
       //ix = col+420;
       ix = col + ((LCDWIDTH * LCDHEIGHT/8) - LCDWIDTH);
       carrybit = 0x1 << col%8;
-      if (carry[col/8] & carrybit) {   // carry, set
+      if (carry[col/8] & carrybit) { // carry, set
         pcd8544_buffer[ix] |= 0x80;
       }
-    }  
+    }
   } //if WRAP
   updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
 }
 
 // scroll screen 1 pixel down
 void Adafruit_PCD8544::scrollDown(boolean WRAP) {
-  uint8_t row, col, carrybit, carryflag, carry[11];
+  uint8_t row, col, carrybit, carryflag, carry[((LCDWIDTH-1) / 8) + 1];
   uint16_t ix;
   
-  memset(&carry[0],0,11);              // clear carry bits
+  memset(&carry[0],0,((LCDWIDTH-1) / 8) + 1); // clear carry bits
   // move from the bottom row( LCDHEIGHT/8 ) up to row 0
   for (row=0; row < LCDHEIGHT/8; row++) {
     for (col=0; col < LCDWIDTH; col++) {
-      ix=(uint16_t)((row*LCDWIDTH) + col);
-      carrybit = 1 << (col%8); 
-      if(row <  LCDHEIGHT/8  && (carry[col/8] & carrybit)) { 
-        // retrieve  carry bit from last(lower) row
+      ix=(uint16_t)((row * LCDWIDTH) + col);
+      carrybit = 1 << (col%8);
+      if(row < LCDHEIGHT/8 && (carry[col/8] & carrybit)) {
+        // retrieve carry bit from last(lower) row
         carryflag = 1;
-        carry[col/8] &= ~carrybit;     // and reset it(ready for another)
+        carry[col/8] &= ~carrybit; // and reset it(ready for another)
       } else {
         carryflag = 0;
-      }                       
+      }
       // remember soon-to-be shifted carrybit
       if ((pcd8544_buffer[ix] & 0x80)) {
         carry[col/8] |= carrybit;
       }
-      pcd8544_buffer[ix] <<= 1;        // shift left(MSb<-LSb(down)) 1 bit
+      pcd8544_buffer[ix] <<= 1; // shift left(MSb<-LSb(down)) 1 bit
       // place carry
       if(carryflag) {
-        pcd8544_buffer[ix] |= 0x01;    // place carry in MSb
+        pcd8544_buffer[ix] |= 0x01; // place carry in MSb
       }
     } // for col
-  } // for row 
+  } // for row
   if (WRAP) {
       for (col=0 ;col < LCDWIDTH; col++) {
       ix = col;
       carrybit = 0x01 << col%8;
-      if (carry[col/8] & carrybit) {   // carry: set pixel
+      if (carry[col/8] & carrybit) { // carry: set pixel
         pcd8544_buffer[ix] |= 0x01;
       }
     }
@@ -283,13 +283,13 @@ void Adafruit_PCD8544::begin(uint8_t contrast) {
     digitalWrite(_rst, HIGH);
   }
 
-  clkport     = portOutputRegister(digitalPinToPort(_sclk));
-  clkpinmask  = digitalPinToBitMask(_sclk);
-  mosiport    = portOutputRegister(digitalPinToPort(_din));
+  clkport = portOutputRegister(digitalPinToPort(_sclk));
+  clkpinmask = digitalPinToBitMask(_sclk);
+  mosiport = portOutputRegister(digitalPinToPort(_din));
   mosipinmask = digitalPinToBitMask(_din);
-  csport    = portOutputRegister(digitalPinToPort(_cs));
+  csport = portOutputRegister(digitalPinToPort(_cs));
   cspinmask = digitalPinToBitMask(_cs);
-  dcport    = portOutputRegister(digitalPinToPort(_dc));
+  dcport = portOutputRegister(digitalPinToPort(_dc));
   dcpinmask = digitalPinToBitMask(_dc);
 
   // get into the EXTENDED mode!
@@ -328,9 +328,9 @@ inline void Adafruit_PCD8544::fastSPIwrite(uint8_t d) {
   
   for(uint8_t bit = 0x80; bit; bit >>= 1) {
     *clkport &= ~clkpinmask;
-    if(d & bit) *mosiport |=  mosipinmask;
-    else        *mosiport &= ~mosipinmask;
-    *clkport |=  clkpinmask;
+    if(d & bit) *mosiport |= mosipinmask;
+    else *mosiport &= ~mosipinmask;
+    *clkport |= clkpinmask;
   }
 }
 
@@ -361,7 +361,7 @@ void Adafruit_PCD8544::setContrast(uint8_t val) {
     val = 0x7f;
   }
   command(PCD8544_FUNCTIONSET | PCD8544_EXTENDEDINSTRUCTION );
-  command( PCD8544_SETVOP | val); 
+  command( PCD8544_SETVOP | val);
   command(PCD8544_FUNCTIONSET);
   
  }
@@ -371,11 +371,11 @@ void Adafruit_PCD8544::setContrast(uint8_t val) {
 void Adafruit_PCD8544::display(void) {
   uint8_t col, maxcol, p;
   
-  for(p = 0; p < 6; p++) {
+  for(p = 0; p < LCDHEIGHT/8; p++) {
 #ifdef enablePartialUpdate
     // check if this page is part of update
     if ( yUpdateMin >= ((p+1)*8) ) {
-      continue;   // nope, skip it!
+      continue; // nope, skip it!
     }
     if (yUpdateMax < p*8) {
       break;
@@ -409,7 +409,7 @@ void Adafruit_PCD8544::display(void) {
 
   }
 
-  command(PCD8544_SETYADDR );  // no idea why this is necessary but it is to finish the last byte?
+  command(PCD8544_SETYADDR ); // no idea why this is necessary but it is to finish the last byte?
 #ifdef enablePartialUpdate
   xUpdateMin = LCDWIDTH - 1;
   xUpdateMax = 0;
@@ -429,9 +429,7 @@ void Adafruit_PCD8544::clearDisplay(void) {
 /*
 // this doesnt touch the buffer, just clears the display RAM - might be handy
 void Adafruit_PCD8544::clearDisplay(void) {
-  
   uint8_t p, c;
-  
   for(p = 0; p < 8; p++) {
 
     st7565_command(CMD_SET_PAGE | p);
@@ -441,9 +439,8 @@ void Adafruit_PCD8544::clearDisplay(void) {
       st7565_command(CMD_SET_COLUMN_LOWER | (c & 0xf));
       st7565_command(CMD_SET_COLUMN_UPPER | ((c >> 4) & 0xf));
       st7565_data(0x0);
-    }     
+    }    
     }
 
 }
-
 */

--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -151,16 +151,16 @@ void Adafruit_PCD8544::scrollLeft(boolean WRAP) {
   uint8_t row, /*col, */ tmp;
   /*uint16_t ix;*/
   for (row=0; row<6; row++) {
-	tmp = pcd8544_buffer[row * LCDWIDTH]; // remember 1st byte
-	memcpy(pcd8544_buffer +(row * LCDWIDTH),
-		   pcd8544_buffer +(row * LCDWIDTH) + 1,
-		   LCDWIDTH - 1);
-	// for (col=0;col<LCDWIDTH-1;col++) {              // 1 line good but ugly
-	  // ix=row*LCDWIDTH+col;                          // 3 lines readable but slower
-	  // pcd8544_buffer[ix] = pcd8544_buffer[ix + 1]; 
-	// }
+    tmp = pcd8544_buffer[row * LCDWIDTH]; // remember 1st byte
+    memcpy(pcd8544_buffer +(row * LCDWIDTH),
+           pcd8544_buffer +(row * LCDWIDTH) + 1,     // 1 line fast but ugly
+           LCDWIDTH - 1);
+//     for (col=0;col<LCDWIDTH-1;col++) { 
+//       ix=row*LCDWIDTH+col;                        // 3 lines readable but slower
+//       pcd8544_buffer[ix] = pcd8544_buffer[ix + 1]; 
+//     }
     // place wrapped byte if required
-	pcd8544_buffer[row * LCDWIDTH + LCDWIDTH - 1] = WRAP ? tmp : 0x00; 	
+    pcd8544_buffer[row * LCDWIDTH + LCDWIDTH - 1] = WRAP ? tmp : 0x00;
   }
   updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
 }
@@ -170,12 +170,12 @@ void Adafruit_PCD8544::scrollRight(boolean WRAP) {
   uint8_t row, col, tmp;
   uint16_t ix;
   for (row=0; row<6; row++) {
-	tmp = pcd8544_buffer[row * LCDWIDTH + LCDWIDTH - 1]; // remember 1st byte
-	for (col=83; col > 0; col--) {
-	  ix=row * LCDWIDTH + col;
-	  pcd8544_buffer[ix] = pcd8544_buffer[ix-1];
-	}
-	pcd8544_buffer[row * LCDWIDTH] = WRAP ? tmp : 0x00;  // place wrapped byte
+    tmp = pcd8544_buffer[row * LCDWIDTH + LCDWIDTH - 1]; // remember 1st byte
+    for (col=83; col > 0; col--) {
+      ix=row * LCDWIDTH + col;
+      pcd8544_buffer[ix] = pcd8544_buffer[ix-1];
+    }
+    pcd8544_buffer[row * LCDWIDTH] = WRAP ? tmp : 0x00;  // place wrapped byte
   }
   updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
 }
@@ -187,39 +187,39 @@ void Adafruit_PCD8544::scrollUp(boolean WRAP) {
   memset(&carry[0],0,11); // clear carry bits
   // move from the bottom row(6) backwards to 0
   for (row=6; row>0; row--) {
-	for (col=0; col < LCDWIDTH; col++) {
-	  ix=(uint16_t)(((row-1) * LCDWIDTH) + col);
-	  carrybit = 0x01 << col%8;
-	  if(row < LCDHEIGHT/8 ) { // 2nd-highest row and below
-		// retrieve and place carry bit from last(higher) row
-		if (carry[col>>3] & carrybit) { 	  // carry is set
-			carryflag = 1;
-			carry[col>>3] &= ~carrybit; // reset this carry bit
-		} else {
-			carryflag = 0;
-		}
-	  } 
-	  // remember soon-to-be shifted bit
-	  if (pcd8544_buffer[ix] & 0x01) { // carry LSb is set
-		carry[col>>3] |= carrybit; //  remember LSb(top bit)
-	  }
-	  pcd8544_buffer[ix] >>= 1; 	// shift right(MSb->LSb(up)) 1 bit
-	  if(carryflag) { 	      
-	    pcd8544_buffer[ix] |= 0x80; // place carry in MSb
-	  }
-	} // for col
+    for (col=0; col < LCDWIDTH; col++) {
+      ix=(uint16_t)(((row-1) * LCDWIDTH) + col);
+      carrybit = 0x01 << col%8;
+      if(row < LCDHEIGHT/8 ) { // 2nd-highest row and below
+        // retrieve and place carry bit from last(higher) row
+        if (carry[col>>3] & carrybit) {       // carry is set
+            carryflag = 1;
+            carry[col>>3] &= ~carrybit; // reset this carry bit
+        } else {
+            carryflag = 0;
+        }
+      } 
+      // remember soon-to-be shifted bit
+      if (pcd8544_buffer[ix] & 0x01) { // carry LSb is set
+        carry[col>>3] |= carrybit; //  remember LSb(top bit)
+      }
+      pcd8544_buffer[ix] >>= 1;     // shift right(MSb->LSb(up)) 1 bit
+      if(carryflag) {           
+        pcd8544_buffer[ix] |= 0x80; // place carry in MSb
+      }
+    } // for col
   } // for row 
   // wrap around shifted-up bits
   if (WRAP) {
-	for (col=0; col < LCDWIDTH; col++) {
-	  //ix = col+420;
-	  ix = col + ((LCDWIDTH * LCDHEIGHT/8) - LCDWIDTH);
-	  carrybit = 0x1 << col%8;
-	  if (carry[col>>3] & carrybit) { // carry, set
-	    pcd8544_buffer[ix] |= 0x80;
-	  } else {
-	    pcd8544_buffer[ix] &= 0x7f; // no carry, reset - REDUNDANT??
-	  }
+    for (col=0; col < LCDWIDTH; col++) {
+      //ix = col+420;
+      ix = col + ((LCDWIDTH * LCDHEIGHT/8) - LCDWIDTH);
+      carrybit = 0x1 << col%8;
+      if (carry[col>>3] & carrybit) { // carry, set
+        pcd8544_buffer[ix] |= 0x80;
+      } else {
+        pcd8544_buffer[ix] &= 0x7f; // no carry, reset - REDUNDANT??
+      }
     }
   } //if WRAP
   updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
@@ -232,37 +232,37 @@ void Adafruit_PCD8544::scrollDown(boolean WRAP) {
   memset(&carry[0],0,11); // clear carry bits
   // move from the bottom row(6) up to row 0
   for (row=0; row < LCDHEIGHT/8; row++) {
-	for (col=0; col < LCDWIDTH; col++) {
-	  ix=(uint16_t)((row*LCDWIDTH) + col);
-	  carrybit=1 << (col%8); 
-	  if(row < 6 && ((carry[col>>3] & carrybit))) { 
-		// retrieve  carry bit from last(lower) row
-		carryflag = 1;
-		carry[col>>3] &= ~carrybit; // and reset it(ready for another)
-	  } else {
-		carryflag = 0;
-	  }			     	  
-	  // remember soon-to-be shifted carrybit
-	  if ((pcd8544_buffer[ix] & 0x80)) { // carry (MSb) is set
-		carry[col>>3] |= carrybit;       // remember it
-	  }
-	  pcd8544_buffer[ix] <<= 1; // shift left(MSb<-LSb(down)) 1 bit
-	  // place carry
-	  if(carryflag) {
-	    pcd8544_buffer[ix] |= 0x01; // place carry in MSb
-	  }
-	} // for col
+    for (col=0; col < LCDWIDTH; col++) {
+      ix=(uint16_t)((row*LCDWIDTH) + col);
+      carrybit=1 << (col%8); 
+      if(row < 6 && ((carry[col>>3] & carrybit))) { 
+        // retrieve  carry bit from last(lower) row
+        carryflag = 1;
+        carry[col>>3] &= ~carrybit; // and reset it(ready for another)
+      } else {
+        carryflag = 0;
+      }                       
+      // remember soon-to-be shifted carrybit
+      if ((pcd8544_buffer[ix] & 0x80)) { // carry (MSb) is set
+        carry[col>>3] |= carrybit;       // remember it
+      }
+      pcd8544_buffer[ix] <<= 1; // shift left(MSb<-LSb(down)) 1 bit
+      // place carry
+      if(carryflag) {
+        pcd8544_buffer[ix] |= 0x01; // place carry in MSb
+      }
+    } // for col
   } // for row 
   if (WRAP) {
-  	for (col=0;col<LCDWIDTH;col++) {
-	  ix = col;
-	  carrybit = 0x01 << col%8;
-	  if (carry[col>>3] & carrybit) { // carry: set pixel
-		pcd8544_buffer[ix] |= 0x01;
-	  } else {
-		pcd8544_buffer[ix] &= 0xFE; // no carry: clear pixel(REDUNDANT??)
-	  }	  
-	}
+      for (col=0;col<LCDWIDTH;col++) {
+      ix = col;
+      carrybit = 0x01 << col%8;
+      if (carry[col>>3] & carrybit) { // carry: set pixel
+        pcd8544_buffer[ix] |= 0x01;
+      } else {
+        pcd8544_buffer[ix] &= 0xFE; // no carry: clear pixel(REDUNDANT??)
+      }
+    }
   }
   updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
 }

--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -128,6 +128,144 @@ uint8_t Adafruit_PCD8544::getPixel(int8_t x, int8_t y) {
   return (pcd8544_buffer[x+ (y/8)*LCDWIDTH] >> (y%8)) & 0x1;  
 }
 
+// blast a native bitmap into the display buffer from program memory
+/*HACK: Unkown why 256 must be subtracted from program-memory pointer*/
+void Adafruit_PCD8544::replace_P(uint8_t *bitmap) {
+  memcpy_P(pcd8544_buffer, (uint8_t*)pgm_read_byte(bitmap - 256), LCDWIDTH*LCDHEIGHT/8); 
+  updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
+}
+
+// blast a native bitmap into the display buffer from working memory(SRAM)
+void Adafruit_PCD8544::replace_S(uint8_t *bitmap) {
+  memcpy(pcd8544_buffer, bitmap, LCDWIDTH*LCDHEIGHT/8);
+  updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
+}
+
+// capture a raw bitmap buffer into memory(SRAM)
+void Adafruit_PCD8544::capture(uint8_t *bitmap) {
+  memcpy(bitmap, pcd8544_buffer, LCDWIDTH*LCDHEIGHT/8);
+}
+
+// scroll screen 1 pixel to the left. 
+void Adafruit_PCD8544::scrollLeft(boolean WRAP) {
+  uint8_t row, /*col, */ tmp;
+  /*uint16_t ix;*/
+  for (row=0; row<6; row++) {
+	tmp = pcd8544_buffer[row * LCDWIDTH]; // remember 1st byte
+	memcpy(pcd8544_buffer +(row * LCDWIDTH),
+		   pcd8544_buffer +(row * LCDWIDTH) + 1,
+		   LCDWIDTH - 1);
+	// for (col=0;col<LCDWIDTH-1;col++) {              // 1 line good but ugly
+	  // ix=row*LCDWIDTH+col;                          // 3 lines readable but slower
+	  // pcd8544_buffer[ix] = pcd8544_buffer[ix + 1]; 
+	// }
+    // place wrapped byte if required
+	pcd8544_buffer[row * LCDWIDTH + LCDWIDTH - 1] = WRAP ? tmp : 0x00; 	
+  }
+  updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
+}
+
+// scroll screen 1 pixel to the right
+void Adafruit_PCD8544::scrollRight(boolean WRAP) {
+  uint8_t row, col, tmp;
+  uint16_t ix;
+  for (row=0; row<6; row++) {
+	tmp = pcd8544_buffer[row * LCDWIDTH + LCDWIDTH - 1]; // remember 1st byte
+	for (col=83; col > 0; col--) {
+	  ix=row * LCDWIDTH + col;
+	  pcd8544_buffer[ix] = pcd8544_buffer[ix-1];
+	}
+	pcd8544_buffer[row * LCDWIDTH] = WRAP ? tmp : 0x00;  // place wrapped byte
+  }
+  updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
+}
+
+void Adafruit_PCD8544::scrollUp(boolean WRAP) {
+  uint8_t row, col, carrybit, carryflag=0, carry[11];
+  uint16_t ix;
+  
+  memset(&carry[0],0,11); // clear carry bits
+  // move from the bottom row(6) backwards to 0
+  for (row=6; row>0; row--) {
+	for (col=0; col < LCDWIDTH; col++) {
+	  ix=(uint16_t)(((row-1) * LCDWIDTH) + col);
+	  carrybit = 0x01 << col%8;
+	  if(row < LCDHEIGHT/8 ) { // 2nd-highest row and below
+		// retrieve and place carry bit from last(higher) row
+		if (carry[col>>3] & carrybit) { 	  // carry is set
+			carryflag=1;
+			carry[col>>3] &= ~carrybit; // reset this carry bit
+		} else {
+			carryflag=0;
+		}
+	  } 
+	  // remember soon-to-be shifted bit
+	  if (pcd8544_buffer[ix] & 0x01) { // carry LSb is set
+		carry[col>>3] |= carrybit; //  remember LSb(top bit)
+	  }
+	  pcd8544_buffer[ix] >>= 1; 	// shift right(MSb->LSb(up)) 1 bit
+	  if(carryflag) { 	      
+	    pcd8544_buffer[ix] |= 0x80; // place carry in MSb
+	  }
+	} // for col
+  } // for row 
+  // wrap around shifted-up bits
+  if (WRAP) {
+	for (col=0; col < LCDWIDTH; col++) {
+	  //ix = col+420;
+	  ix = col + ((LCDWIDTH * LCDHEIGHT/8) - LCDWIDTH);
+	  carrybit = 0x1 << col%8;
+	  if (carry[col>>3] & carrybit) { // carry, set
+	    pcd8544_buffer[ix] |= 0x80;
+	  } else {
+	    pcd8544_buffer[ix] &= 0x7f; // no carry, reset - REDUNDANT??
+	  }
+    }
+  } //if WRAP
+  updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
+}
+
+void Adafruit_PCD8544::scrollDown(boolean WRAP) {
+  uint8_t row, col, carrybit, carryflag, carry[11];
+  uint16_t ix;
+  
+  memset(&carry[0],0,11); // clear carry bits
+  // move from the bottom row(6) up to row 0
+  for (row=0; row < LCDHEIGHT/8; row++) {
+	for (col=0; col < LCDWIDTH; col++) {
+	  ix=(uint16_t)((row*LCDWIDTH) + col);
+	  carrybit=1 << (col%8); 
+	  if(row < 6 && ((carry[col>>3] & carrybit))) { 
+		// retrieve  carry bit from last(lower) row
+		carryflag = 0x01;
+		carry[col>>3] &= ~carrybit; // and reset it(ready for another)
+	  } else {
+		carryflag = 0x00;
+	  }			     	  
+	  // remember soon-to-be shifted carrybit
+	  if ((pcd8544_buffer[ix] & 0x80)) { // carry (MSb) is set
+		carry[col>>3] |= carrybit;       // remember it
+	  }
+	  pcd8544_buffer[ix] <<= 1; // shift left(MSb<-LSb(down)) 1 bit
+	  // place carry
+	  if(carryflag) {
+	    pcd8544_buffer[ix] |= 0x01; // place carry in MSb
+	  }
+	} // for col
+  } // for row 
+  if (WRAP) {
+  	for (col=0;col<LCDWIDTH;col++) {
+	  ix = col;
+	  carrybit = 0x01 << col%8;
+	  if (carry[col>>3] & carrybit) { // carry: set pixel
+		pcd8544_buffer[ix] |= 0x01;
+	  } else {
+		pcd8544_buffer[ix] &= 0xFE; // no carry: clear pixel(REDUNDANT??)
+	  }	  
+	}
+  }
+  updateBoundingBox(0, 0, LCDWIDTH-1, LCDHEIGHT-1);
+}
 
 void Adafruit_PCD8544::begin(uint8_t contrast) {
   // set pin directions

--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -193,10 +193,10 @@ void Adafruit_PCD8544::scrollUp(boolean WRAP) {
 	  if(row < LCDHEIGHT/8 ) { // 2nd-highest row and below
 		// retrieve and place carry bit from last(higher) row
 		if (carry[col>>3] & carrybit) { 	  // carry is set
-			carryflag=1;
+			carryflag = 1;
 			carry[col>>3] &= ~carrybit; // reset this carry bit
 		} else {
-			carryflag=0;
+			carryflag = 0;
 		}
 	  } 
 	  // remember soon-to-be shifted bit
@@ -237,10 +237,10 @@ void Adafruit_PCD8544::scrollDown(boolean WRAP) {
 	  carrybit=1 << (col%8); 
 	  if(row < 6 && ((carry[col>>3] & carrybit))) { 
 		// retrieve  carry bit from last(lower) row
-		carryflag = 0x01;
+		carryflag = 1;
 		carry[col>>3] &= ~carrybit; // and reset it(ready for another)
 	  } else {
-		carryflag = 0x00;
+		carryflag = 0;
 	  }			     	  
 	  // remember soon-to-be shifted carrybit
 	  if ((pcd8544_buffer[ix] & 0x80)) { // carry (MSb) is set

--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -152,12 +152,12 @@ void Adafruit_PCD8544::scrollLeft(boolean WRAP) {
   uint8_t row, /*col, */ tmp;
   /*uint16_t ix;*/
   for (row=0; row < LCDHEIGHT/8; row++) {
-    tmp = pcd8544_buffer[row * LCDWIDTH];        // remember 1st byte
+    tmp = pcd8544_buffer[row * LCDWIDTH];         // remember 1st byte
     memcpy(pcd8544_buffer + (row * LCDWIDTH),
            pcd8544_buffer + (row * LCDWIDTH) + 1, // 1 line fast but ugly
-           LCDWIDTH - 1);
+           LCDWIDTH-1);
 //     for (col=0;col<LCDWIDTH-1;col++) { 
-//       ix=row*LCDWIDTH+col;                    // 3 lines readable but slower
+//       ix=row*LCDWIDTH+col;                     // 3 lines readable but slower
 //       pcd8544_buffer[ix] = pcd8544_buffer[ix + 1]; 
 //     }
     // place wrapped byte if required
@@ -183,10 +183,10 @@ void Adafruit_PCD8544::scrollRight(boolean WRAP) {
 
 // scroll screen 1 pixel up
 void Adafruit_PCD8544::scrollUp(boolean WRAP) {
-  uint8_t row, col, carrybit, carryflag=0, carry[11];
+  uint8_t row, col, carrybit, carryflag=0, carry[((LCDWIDTH-1) / 8) + 1];
   uint16_t ix;
   
-  memset(&carry[0],0,11); // clear carry bits
+  memset(&carry[0],0,((LCDWIDTH-1) / 8) + 1); // clear carry bits
   // move from the bottom row backwards to 0
   for (row= LCDHEIGHT/8 ; row > 0; row--) {
     for (col=0; col < LCDWIDTH; col++) {
@@ -227,10 +227,10 @@ void Adafruit_PCD8544::scrollUp(boolean WRAP) {
 
 // scroll screen 1 pixel down
 void Adafruit_PCD8544::scrollDown(boolean WRAP) {
-  uint8_t row, col, carrybit, carryflag, carry[11];
+  uint8_t row, col, carrybit, carryflag, carry[((LCDWIDTH-1) / 8) + 1];
   uint16_t ix;
   
-  memset(&carry[0],0,11);              // clear carry bits
+  memset(&carry[0],0,((LCDWIDTH-1) / 8) + 1);              // clear carry bits
   // move from the bottom row( LCDHEIGHT/8 ) up to row 0
   for (row=0; row < LCDHEIGHT/8; row++) {
     for (col=0; col < LCDWIDTH; col++) {
@@ -371,7 +371,7 @@ void Adafruit_PCD8544::setContrast(uint8_t val) {
 void Adafruit_PCD8544::display(void) {
   uint8_t col, maxcol, p;
   
-  for(p = 0; p < 6; p++) {
+  for(p = 0; p < ((LCDHEIGHT-1) / 8) + 1; p++) {
 #ifdef enablePartialUpdate
     // check if this page is part of update
     if ( yUpdateMin >= ((p+1)*8) ) {

--- a/Adafruit_PCD8544.cpp
+++ b/Adafruit_PCD8544.cpp
@@ -152,12 +152,12 @@ void Adafruit_PCD8544::scrollLeft(boolean WRAP) {
   uint8_t row, /*col, */ tmp;
   /*uint16_t ix;*/
   for (row=0; row < LCDHEIGHT/8; row++) {
-    tmp = pcd8544_buffer[row * LCDWIDTH];         // remember 1st byte
+    tmp = pcd8544_buffer[row * LCDWIDTH];        // remember 1st byte
     memcpy(pcd8544_buffer + (row * LCDWIDTH),
            pcd8544_buffer + (row * LCDWIDTH) + 1, // 1 line fast but ugly
-           LCDWIDTH-1);
+           LCDWIDTH - 1);
 //     for (col=0;col<LCDWIDTH-1;col++) { 
-//       ix=row*LCDWIDTH+col;                     // 3 lines readable but slower
+//       ix=row*LCDWIDTH+col;                    // 3 lines readable but slower
 //       pcd8544_buffer[ix] = pcd8544_buffer[ix + 1]; 
 //     }
     // place wrapped byte if required
@@ -183,10 +183,10 @@ void Adafruit_PCD8544::scrollRight(boolean WRAP) {
 
 // scroll screen 1 pixel up
 void Adafruit_PCD8544::scrollUp(boolean WRAP) {
-  uint8_t row, col, carrybit, carryflag=0, carry[((LCDWIDTH-1) / 8) + 1];
+  uint8_t row, col, carrybit, carryflag=0, carry[11];
   uint16_t ix;
   
-  memset(&carry[0],0,((LCDWIDTH-1) / 8) + 1); // clear carry bits
+  memset(&carry[0],0,11); // clear carry bits
   // move from the bottom row backwards to 0
   for (row= LCDHEIGHT/8 ; row > 0; row--) {
     for (col=0; col < LCDWIDTH; col++) {
@@ -227,10 +227,10 @@ void Adafruit_PCD8544::scrollUp(boolean WRAP) {
 
 // scroll screen 1 pixel down
 void Adafruit_PCD8544::scrollDown(boolean WRAP) {
-  uint8_t row, col, carrybit, carryflag, carry[((LCDWIDTH-1) / 8) + 1];
+  uint8_t row, col, carrybit, carryflag, carry[11];
   uint16_t ix;
   
-  memset(&carry[0],0,((LCDWIDTH-1) / 8) + 1);              // clear carry bits
+  memset(&carry[0],0,11);              // clear carry bits
   // move from the bottom row( LCDHEIGHT/8 ) up to row 0
   for (row=0; row < LCDHEIGHT/8; row++) {
     for (col=0; col < LCDWIDTH; col++) {
@@ -371,7 +371,7 @@ void Adafruit_PCD8544::setContrast(uint8_t val) {
 void Adafruit_PCD8544::display(void) {
   uint8_t col, maxcol, p;
   
-  for(p = 0; p < ((LCDHEIGHT-1) / 8) + 1; p++) {
+  for(p = 0; p < 6; p++) {
 #ifdef enablePartialUpdate
     // check if this page is part of update
     if ( yUpdateMin >= ((p+1)*8) ) {

--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -66,6 +66,14 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   uint8_t getPixel(int8_t x, int8_t y);
 
+  void replace_P(uint8_t *bitmap);
+  void replace_S(uint8_t *bitmap);
+  void capture(uint8_t *bitmap); 
+  void scrollLeft(boolean WRAP);
+  void scrollRight(boolean WRAP);
+  void scrollUp(boolean WRAP);
+  void scrollDown(boolean WRAP);
+
  private:
   int8_t _din, _sclk, _dc, _rst, _cs;
   volatile uint8_t *mosiport, *clkport, *csport, *dcport;

--- a/Adafruit_PCD8544.h
+++ b/Adafruit_PCD8544.h
@@ -66,13 +66,14 @@ class Adafruit_PCD8544 : public Adafruit_GFX {
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   uint8_t getPixel(int8_t x, int8_t y);
 
+  void capture  (uint8_t *bitmap);
   void replace_P(uint8_t *bitmap);
   void replace_S(uint8_t *bitmap);
-  void capture(uint8_t *bitmap); 
-  void scrollLeft(boolean WRAP);
+  
+  void scrollLeft (boolean WRAP);
   void scrollRight(boolean WRAP);
-  void scrollUp(boolean WRAP);
-  void scrollDown(boolean WRAP);
+  void scrollUp   (boolean WRAP);
+  void scrollDown (boolean WRAP);
 
  private:
   int8_t _din, _sclk, _dc, _rst, _cs;

--- a/examples/pcdtest/pcdtest.pde
+++ b/examples/pcdtest/pcdtest.pde
@@ -340,7 +340,7 @@ void testScroll() {
     display.scrollLeft(WRAP); display.scrollUp(WRAP);
     display.display(); delay(30);
   }
-  for ( x=0; x < 12; x++) {
+  for ( x=0; x < 24; x++) {
     display.scrollRight(WRAP); display.display(); delay(50);
   }  
   for ( x=0; x < 24; x++) {

--- a/examples/pcdtest/pcdtest.pde
+++ b/examples/pcdtest/pcdtest.pde
@@ -69,7 +69,7 @@ void setup()   {
 
   display.display(); // show splashscreen
   delay(2000);
-  display.capture(my_screenshot); // save screenshot for later
+  display.capture(&my_screenshot[0]); // save screenshot for later
   display.clearDisplay();   // clears the screen and buffer
 
   // draw a single pixel
@@ -155,7 +155,7 @@ void setup()   {
   delay(1000); 
 
   // replace screen with earlier screenshot
-  display.replace_S(my_screenshot);
+  display.replace_S(&my_screenshot[0]);
 
   // scroll around a bit
   testScroll();

--- a/examples/pcdtest/pcdtest.pde
+++ b/examples/pcdtest/pcdtest.pde
@@ -340,7 +340,7 @@ void testScroll() {
     display.scrollLeft(WRAP); display.scrollUp(WRAP);
     display.display(); delay(30);
   }
-  for ( x=0; x < 12; x++) {
+  for ( x=0; x < 32; x++) {
     display.scrollRight(WRAP); display.display(); delay(50);
   }  
   for ( x=0; x < 24; x++) {

--- a/examples/pcdtest/pcdtest.pde
+++ b/examples/pcdtest/pcdtest.pde
@@ -336,17 +336,20 @@ void testdrawline() {
 void testScroll() {
   uint8_t x;
   
-  for ( x=0; x < 24; x++) {
-    display.scrollLeft(WRAP);   display.display(); delay(50);
+  for ( x=0; x < 96; x++) {
+    display.scrollLeft(WRAP); display.scrollUp(WRAP);
+    display.display(); delay(30);
   }
-  for ( x=0; x < 16; x++) {
-    display.scrollRight(WRAP);  display.display(); delay(50);
+  for ( x=0; x < 12; x++) {
+    display.scrollRight(WRAP); display.display(); delay(50);
   }  
-  for ( x=0; x < 32; x++) {
-    display.scrollUp(WRAP);     display.display(); delay(50);
+  for ( x=0; x < 24; x++) {
+    display.scrollDown(WRAP);  display.display(); delay(50);
+  }
+  for ( x=0; x < 24; x++) {
+    display.scrollUp(WRAP);    display.display(); delay(25);
   }
   for ( x=0; x < 48; x++) {
-    display.scrollDown(NOWRAP); display.display(); delay(50);
-  }
-  
+    display.scrollUp(NOWRAP);  display.display(); delay(5);
+  } 
 }

--- a/examples/pcdtest/pcdtest.pde
+++ b/examples/pcdtest/pcdtest.pde
@@ -340,7 +340,7 @@ void testScroll() {
     display.scrollLeft(WRAP); display.scrollUp(WRAP);
     display.display(); delay(30);
   }
-  for ( x=0; x < 24; x++) {
+  for ( x=0; x < 12; x++) {
     display.scrollRight(WRAP); display.display(); delay(50);
   }  
   for ( x=0; x < 24; x++) {

--- a/examples/pcdtest/pcdtest.pde
+++ b/examples/pcdtest/pcdtest.pde
@@ -30,6 +30,8 @@ Adafruit_PCD8544 display = Adafruit_PCD8544(7, 6, 5, 4, 3);
 #define XPOS 0
 #define YPOS 1
 #define DELTAY 2
+#define WRAP 1
+#define NOWRAP 0
 
 
 #define LOGO16_GLCD_HEIGHT 16
@@ -53,6 +55,8 @@ static unsigned char PROGMEM logo16_glcd_bmp[] =
   B01110000, B01110000,
   B00000000, B00110000 };
 
+static uint8_t my_screenshot[LCDWIDTH * LCDHEIGHT/8]; 
+  
 void setup()   {
   Serial.begin(9600);
 
@@ -65,6 +69,7 @@ void setup()   {
 
   display.display(); // show splashscreen
   delay(2000);
+  display.capture(my_screenshot); // save screenshot for later
   display.clearDisplay();   // clears the screen and buffer
 
   // draw a single pixel
@@ -149,6 +154,12 @@ void setup()   {
   display.invertDisplay(false);
   delay(1000); 
 
+  // replace screen with earlier screenshot
+  display.replace_S(my_screenshot);
+
+  // scroll around a bit
+  testScroll();
+  
   // draw a bitmap icon and 'animate' movement
   testdrawbitmap(logo16_glcd_bmp, LOGO16_GLCD_HEIGHT, LOGO16_GLCD_WIDTH);
 }
@@ -320,4 +331,22 @@ void testdrawline() {
     display.display();
   }
   delay(250);
+}
+
+void testScroll() {
+  uint8_t x;
+  
+  for ( x=0; x < 24; x++) {
+    display.scrollLeft(WRAP);   display.display(); delay(50);
+  }
+  for ( x=0; x < 16; x++) {
+    display.scrollRight(WRAP);  display.display(); delay(50);
+  }  
+  for ( x=0; x < 32; x++) {
+    display.scrollUp(WRAP);     display.display(); delay(50);
+  }
+  for ( x=0; x < 48; x++) {
+    display.scrollDown(NOWRAP); display.display(); delay(50);
+  }
+  
 }


### PR DESCRIPTION
Fast native buffer access utilities:
+replace screen buffer from PROGMEM or SRAM
+screenshot to SRAM in native format
Pixelwise whole-of-screen scrolling with optional wrap-around:
+up, down, left, right